### PR TITLE
fix!: use @helia/delegated-routing-v1-http-api-client internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,49 @@
-# @libp2p/http-v1-content-routing <!-- omit in toc -->
+# @libp2p/delegated-routing-v1-http-api-content-routing <!-- omit in toc -->
 
 [![libp2p.io](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![Discuss](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg?style=flat-square)](https://discuss.libp2p.io)
-[![codecov](https://img.shields.io/codecov/c/github/libp2p/js-http-v1-content-routing.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-http-v1-content-routing)
-[![CI](https://img.shields.io/github/actions/workflow/status/libp2p/js-http-v1-content-routing/js-test-and-release.yml?branch=main\&style=flat-square)](https://github.com/libp2p/js-http-v1-content-routing/actions/workflows/js-test-and-release.yml?query=branch%3Amain)
+[![codecov](https://img.shields.io/codecov/c/github/libp2p/js-delegated-routing-v1-http-api-content-routing.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-delegated-routing-v1-http-api-content-routing)
+[![CI](https://img.shields.io/github/actions/workflow/status/libp2p/js-delegated-routing-v1-http-api-content-routing/js-test-and-release.yml?branch=main\&style=flat-square)](https://github.com/libp2p/js-delegated-routing-v1-http-api-content-routing/actions/workflows/js-test-and-release.yml?query=branch%3Amain)
 
-> Use a Routing V1 HTTP service to discover content providers
+> Use a Delegated Routing V1 HTTP service to discover content providers
+
+This is a [ContentRouting](https://libp2p.github.io/js-libp2p/interfaces/_libp2p_interface.content_routing.ContentRouting.html)
+implementation that makes use of the [@helia/delegated-routing-v1-http-api-client](https://www.npmjs.com/package/@helia/delegated-routing-v1-http-api-client)
+to use servers that implement the snappily-titled [Delegated Routing V1 HTTP API](Delegated Routing V1 HTTP API)
+spec to get/put IPNS records and to resolve providers for CIDs.
 
 ## Table of contents <!-- omit in toc -->
 
-- [Install](#install)
-  - [Browser `<script>` tag](#browser-script-tag)
+- - [Install](#install)
+    - [Browser `<script>` tag](#browser-script-tag)
 - [Example](#example)
-- [API Docs](#api-docs)
-- [License](#license)
-- [Contribution](#contribution)
+  - [API Docs](#api-docs)
+  - [License](#license)
+  - [Contribution](#contribution)
 
 ## Install
 
 ```console
-$ npm i @libp2p/http-v1-content-routing
+$ npm i @libp2p/delegated-routing-v1-http-api-content-routing
 ```
 
 ### Browser `<script>` tag
 
-Loading this module through a script tag will make it's exports available as `Libp2pHttpV1ContentRouting` in the global namespace.
+Loading this module through a script tag will make it's exports available as `Libp2pDelegatedRoutingV1HttpApiContentRouting` in the global namespace.
 
 ```html
-<script src="https://unpkg.com/@libp2p/http-v1-content-routing/dist/index.min.js"></script>
+<script src="https://unpkg.com/@libp2p/delegated-routing-v1-http-api-content-routing/dist/index.min.js"></script>
 ```
 
-## Example
+# Example
 
 ```js
 import { createLibp2p } from 'libp2p'
-import { reframeContentRouting } from '@libp2p/reframe-content-routing'
+import { delgatedRoutingV1HTTPAPIContentRouting } from '@libp2p/delegated-routing-http-v1-content-routing'
 
 const node = await createLibp2p({
   contentRouters: [
-    reframeContentRouting('https://cid.contact/reframe')
+    delgatedRoutingV1HTTPAPIContentRouting('https://example.org')
   ]
   //.. other config
 })
@@ -51,7 +56,7 @@ for await (const provider of node.contentRouting.findProviders('cid')) {
 
 ## API Docs
 
-- <https://libp2p.github.io/js-http-v1-content-routing>
+- <https://libp2p.github.io/js-delegated-routing-v1-http-api-content-routing>
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@libp2p/http-v1-content-routing",
-  "version": "1.0.2",
-  "description": "Use a Routing V1 HTTP service to discover content providers",
+  "name": "@libp2p/delegated-routing-v1-http-api-content-routing",
+  "version": "0.0.0",
+  "description": "Use a Delegated Routing V1 HTTP service to discover content providers",
   "license": "Apache-2.0 OR MIT",
-  "homepage": "https://github.com/libp2p/js-http-v1-content-routing#readme",
+  "homepage": "https://github.com/libp2p/js-delegated-routing-v1-http-api-content-routing#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/libp2p/js-http-v1-content-routing.git"
+    "url": "git+https://github.com/libp2p/js-delegated-routing-v1-http-api-content-routing.git"
   },
   "bugs": {
-    "url": "https://github.com/libp2p/js-http-v1-content-routing/issues"
+    "url": "https://github.com/libp2p/js-delegated-routing-v1-http-api-content-routing/issues"
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
@@ -130,20 +130,17 @@
     "test:node": "aegir test -t node --cov",
     "test:electron-main": "aegir test -t electron-main",
     "release": "aegir release",
-    "docs": "aegir docs"
+    "docs": "aegir docs -- --includeVersion false"
   },
   "dependencies": {
+    "@helia/delegated-routing-v1-http-api-client": "^1.0.1",
     "@libp2p/interface": "^0.1.1",
     "@libp2p/logger": "^3.0.1",
     "@libp2p/peer-id": "^3.0.1",
-    "@multiformats/multiaddr": "^12.1.2",
-    "any-signal": "^4.1.1",
-    "browser-readablestream-to-it": "^2.0.2",
-    "it-to-buffer": "^4.0.1",
+    "ipns": "^7.0.1",
+    "it-map": "^3.0.4",
     "multiformats": "^12.0.1",
-    "p-defer": "^4.0.0",
-    "p-queue": "^7.3.4",
-    "uint8arrays": "^4.0.3"
+    "uint8arrays": "^4.0.6"
   },
   "devDependencies": {
     "@libp2p/peer-id-factory": "^3.0.2",


### PR DESCRIPTION
Refactors the internal implementation to use the [@helia/delegated-routing-v1-http-api-client](https://www.npmjs.com/package/@helia/delegated-routing-v1-http-api-client) instead of a hand-rolled version.

Replaces any older references to "Reframe" with the new name of "Delegated Routing V1 HTTP API".  Phew.

BREAKING CHANGE: the module has been renamed as the spec has been renamed